### PR TITLE
feat: 로그인 시 헤더 영역 유저 프로필 사진으로 변경

### DIFF
--- a/components/Layout/Header/index.tsx
+++ b/components/Layout/Header/index.tsx
@@ -20,6 +20,11 @@ export default function Header() {
 
   if (pathname.includes('/diary/post')) return null
 
+  const getUserProfile = () => {
+    const userInfo = JSON.parse(localStorage.getItem('userInfo') || '{}')
+    return userInfo.profile
+  }
+
   return (
     <header className="z-30 fixed top-0 left-0 bg-background w-full py-[12px] px-[5%] flex items-center justify-between">
       <Logo />
@@ -51,7 +56,7 @@ export default function Header() {
         {isLogin ? (
           <Button type="button" ariaLabel="zz" onClick={() => setIsNavModalOpen((prev) => !prev)}>
             <Image
-              src="/images/dfsfs.jpeg"
+              src={getUserProfile()}
               alt="user profile"
               width={50}
               height={50}

--- a/components/Page/Auth/Modal/Login.tsx
+++ b/components/Page/Auth/Modal/Login.tsx
@@ -57,13 +57,24 @@ export default function LoginModal({ isOpen, handleClose }: LoginModalProps) {
 
   const mutation = useMutation({
     mutationFn: () => login(email, password),
-    onSuccess: () => {
-      const { href } = window.location
+    onSuccess: (data) => {
+      console.log(data)
 
+      const { userId, userNickname, userProfileImage } = data
+
+      localStorage.setItem(
+        'userInfo',
+        JSON.stringify({
+          userId,
+          nickname: userNickname,
+          profile: userProfileImage,
+        })
+      )
+
+      const { href } = window.location
       if (/sign(in|up)/.test(href)) {
         router.push('/')
       }
-
       setLogin()
       setEmail('')
       setPassword('')

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -43,7 +43,7 @@ export const login = async (userEmail: string, userPassword: string) => {
         localStorage.setItem('authToken', token)
       }
 
-      return data
+      return data.data
     }
   } catch (error) {
     throw new Error('next 서버 요청 중 에러 발생')


### PR DESCRIPTION
<!-- 깔끔한 PR을 남기자! 사용하지 않는 카테고리 부분은 제거해서 PR 생성 -->

## 📌 Intro
<!-- 관련있는 이슈 번호(#000)을 적어 주세요! ex) - #1 -->
- #88

## 📘 Content
<!-- 개발한 내용의 설명을 적어 주세요! -->
-로그인 시 헤더 영역 유저 프로필 사진으로 변경 및 userInfo 로컬 스토리지에 저장